### PR TITLE
Update scope to just request basic info

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -22,7 +22,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['activity', 'nutrition', 'profile', 'settings', 'sleep', 'social', 'weight'];
+    protected $scopes = ['profile'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
If more scopes are needed you can always request more scopes. The problem with specifying all of them as the default is that you cannot remove these default scopes, and for my project I don't need all of this information.
